### PR TITLE
Includes check for views in screenshots module and changes to nearest cuts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 TODO.md
 deprecated
 package
+.idea


### PR DESCRIPTION
This pull request tries to solve the issue #11 . It includes a check in the selected views for the screenshots module to see whether or not the selected cuts are compatible with the volumetric data. If not compatible the nearest compatible cut is computed and the view is changes to that one. This allows the screenshots module to work with images with voxel size different than 1mm and  avoids interpolation of volumetric data.