### PR TITLE
Add traits package requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ pyrr
 PyQt6
 whippersnappy>=2.1.0
 neuroreg>=0.10.1
+traits>=7


### PR DESCRIPTION
Specifies traits package version for compatibility with Python 3.13 on MacOs and Windows